### PR TITLE
Refactor: replace hardcoded Notion field names with enum constants

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse, parse_qs
 
 from app.core.processor import AlbumProcessor, AudioProcessor
 from app.api.middlewares import verify_api_key
+from app.constants.notion_fields import AlbumField, AudioField
 from app.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -61,7 +62,7 @@ async def webhook_data_source(request: WebhookDataSourceRequest) -> WebhookRespo
 
     try:
         # 从Notion数据中提取album id
-        album_id = request.data["properties"]["FanjiaoAlbumID"]["number"]
+        album_id = request.data["properties"][AlbumField.FANJIAO_ALBUM_ID]["number"]
         album_id = str(album_id) if album_id is not None else ""
         logger.info(f"Extracted Album ID: {album_id}")
 
@@ -182,7 +183,7 @@ async def webhook_song(
 
     try:
         # 从请求中提取url
-        url = request.data["properties"]["Audio_URL"]["url"]
+        url = request.data["properties"][AudioField.AUDIO_URL]["url"]
         logger.info(f"Extracted URL: {url}")
 
         if not url:
@@ -257,7 +258,7 @@ async def webhook_song_update(
 
     try:
         # 从请求中提取url
-        url = request.data["properties"]["Audio_URL"]["url"]
+        url = request.data["properties"][AudioField.AUDIO_URL]["url"]
         logger.info(f"Extracted URL: {url}")
 
         if not url:
@@ -298,15 +299,15 @@ async def webhook_song_update(
         logger.info(f"Page ID: {page_id}, Data Source ID: {data_source_id}")
 
         # 处理需要更新的数据
-        update_selection: list = request.data["properties"]["UpdateAudioSelection"][
-            "multi_select"
-        ]
+        update_selection: list = request.data["properties"][
+            AudioField.UPDATE_AUDIO_SELECTION
+        ]["multi_select"]
         if not update_selection:
             logger.info("No updates selected")
             return WebhookResponse(
                 status="info", message="No updates selected in Notion data"
             )
-        update_fields = [item["name"] for item in update_selection]
+        update_fields = [AudioField(item["name"]) for item in update_selection]
         logger.info(f"Fields to update: {update_fields}")
 
         # 进行更新处理
@@ -348,7 +349,7 @@ async def webhook_data_source_update(
 
     try:
         # 从Notion数据中提取album id
-        album_id = request.data["properties"]["FanjiaoAlbumID"]["number"]
+        album_id = request.data["properties"][AlbumField.FANJIAO_ALBUM_ID]["number"]
         album_id = str(album_id) if album_id is not None else ""
         logger.info(f"Extracted Album ID: {album_id}")
 
@@ -363,15 +364,15 @@ async def webhook_data_source_update(
         logger.info(f"Page ID: {page_id}")
 
         # 处理需要更新的数据
-        update_selection: list = request.data["properties"]["Update_selection"][
-            "multi_select"
-        ]
+        update_selection: list = request.data["properties"][
+            AlbumField.UPDATE_SELECTION
+        ]["multi_select"]
         if not update_selection:
             logger.info("No updates selected")
             return WebhookResponse(
                 status="info", message="No updates selected in Notion data"
             )
-        update_fields = [item["name"] for item in update_selection]
+        update_fields = [AlbumField(item["name"]) for item in update_selection]
         logger.info(f"Fields to update: {update_fields}")
 
         # 进行更新处理

--- a/app/clients/notion.py
+++ b/app/clients/notion.py
@@ -6,7 +6,7 @@ Notion API客户端
 负责与Notion API进行交互（异步版本）
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 from notion_client import AsyncClient
 
 from app.constants.notion_fields import AlbumField, AudioField
@@ -111,151 +111,108 @@ class NotionClient:
 
     @staticmethod
     def build_properties(
-        name: str,
-        cover: str,
-        description: str,
-        description_sequel: str,
-        publish_date: str,
-        update_frequency: List[Dict[str, str]],
-        ori_price: int,
-        author_name: str,
-        up_name: str,
-        tags: List[Dict[str, str]],
-        source: str,
-        main_cv: List[Dict[str, str]],
-        main_cv_role: List[Dict[str, str]],
-        supporting_cv: List[Dict[str, str]],
-        supporting_cv_role: List[Dict[str, str]],
-        commercial_drama: str,
-        episode_count: int,
-        album_link: str,
         platform: str = "饭角",
         time_zone: str = "Asia/Shanghai",
+        **data: Any,
     ) -> Dict[str, Any]:
         """
         构建Notion页面属性
 
         Args:
-            name: 专辑名称
-            cover: 封面海报file_upload_id
-            description: 简介
-            description_sequel: 简介续
-            publish_date: 发布日期
-            update_frequency: 更新频率
-            ori_price: 原价
-            author_name: 原著作者
-            up_name: up主
-            tags: 标签列表
-            source: 来源（改编/原创）
-            main_cv: 主役CV
-            main_cv_role: 主役角色
-            supporting_cv: 协役CV
-            supporting_cv_role: 协役角色
-            commercial_drama: 商剧标识
-            episode_count: 集数
-            album_link: 专辑链接
-            platform: 平台
-            time_zone: 时区
+            platform: 平台，默认 饭角
+            time_zone: 时区，默认 Asia/Shanghai
+            **data: 专辑数据字段（name, cover, description, publish_date 等）
 
         Returns:
             Notion页面属性字典
         """
         F = AlbumField
+        cover = data.get("cover")
+        author_name = data.get("author_name", "")
+        up_name = data.get("up_name", "")
+
         return {
-            F.NAME: {"title": [{"text": {"content": name}}]},
+            F.NAME: {"title": [{"text": {"content": data.get("name", "")}}]},
             F.COVER: {"files": [{"type": "file_upload", "file_upload": {"id": cover}}]}
             if cover
             else {"files": []},
-            F.DESCRIPTION: {"rich_text": [{"text": {"content": description}}]},
+            F.DESCRIPTION: {
+                "rich_text": [{"text": {"content": data.get("description", "")}}]
+            },
             F.DESCRIPTION_SEQUEL: {
-                "rich_text": [{"text": {"content": description_sequel}}]
+                "rich_text": [{"text": {"content": data.get("description_sequel", "")}}]
             },
             F.PUBLISH_DATE: {
                 "date": {
-                    "start": publish_date,
+                    "start": data.get("publish_date", ""),
                     "time_zone": time_zone,
                 }
             },
-            F.UPDATE_FREQ: {"multi_select": update_frequency},
-            F.PRICE: {"number": ori_price},
+            F.UPDATE_FREQ: {"multi_select": data.get("update_frequency", [])},
+            F.PRICE: {"number": data.get("ori_price", 0)},
             F.AUTHOR: {"select": {"name": author_name}}
             if author_name
             else {"select": None},
             F.UP_NAME: {"select": {"name": up_name}} if up_name else {"select": None},
-            F.TAGS: {"multi_select": tags},
-            F.SOURCE: {"select": {"name": source}},
-            F.MAIN_CV: {"multi_select": main_cv},
-            F.MAIN_CV_ROLE: {"multi_select": main_cv_role},
-            F.SUPPORTING_CV: {"multi_select": supporting_cv},
-            F.SUPPORTING_CV_ROLE: {"multi_select": supporting_cv_role},
-            F.COMMERCIAL: {"select": {"name": commercial_drama}},
-            F.EPISODE_COUNT: {"number": episode_count},
-            F.ALBUM_LINK: {"url": album_link},
+            F.TAGS: {"multi_select": data.get("tags", [])},
+            F.SOURCE: {"select": {"name": data.get("source", "")}},
+            F.MAIN_CV: {"multi_select": data.get("main_cv", [])},
+            F.MAIN_CV_ROLE: {"multi_select": data.get("main_cv_role", [])},
+            F.SUPPORTING_CV: {"multi_select": data.get("supporting_cv", [])},
+            F.SUPPORTING_CV_ROLE: {"multi_select": data.get("supporting_cv_role", [])},
+            F.COMMERCIAL: {"select": {"name": data.get("commercial_drama", "")}},
+            F.EPISODE_COUNT: {"number": data.get("episode_count", 0)},
+            F.ALBUM_LINK: {"url": data.get("album_link", "")},
             F.PLATFORM: {"multi_select": [{"name": platform}]},
         }
 
     @staticmethod
     def build_audio_properties(
-        name: str,
-        publish_date: str,
-        description: str,
-        cover: str,
-        play: int,
-        singer: Optional[List[dict]] = None,
-        lyricist: Optional[List[dict]] = None,
-        composer: Optional[List[dict]] = None,
-        arranger: Optional[List[dict]] = None,
-        mixer: Optional[List[dict]] = None,
-        lyrics: str = "",
         platform: str = "饭角",
         time_zone: str = "Asia/Shanghai",
+        **data: Any,
     ) -> Dict[str, Any]:
         """
         构建Notion音频页面属性
 
         Args:
-            name: 音频名称
-            publish_date: 发布日期
-            description: 描述
-            cover: 封面
-            singer: 演唱
-            lyricist: 作词
-            composer: 作曲
-            arranger: 编曲
-            mixer: 混音
-            lyrics: 歌词
-            platform: 平台
-            time_zone: 时区
+            platform: 平台，默认 饭角
+            time_zone: 时区，默认 Asia/Shanghai
+            **data: 音频数据字段（name, cover, description, publish_date 等）
 
         Returns:
             Notion音频页面属性字典
         """
         F = AudioField
+        cover = data.get("cover")
+
         return {
-            F.NAME: {"title": [{"text": {"content": name}}]},
+            F.NAME: {"title": [{"text": {"content": data.get("name", "")}}]},
             F.PUBLISH_DATE: {
                 "date": {
-                    "start": publish_date,
+                    "start": data.get("publish_date", ""),
                     "time_zone": time_zone,
                 }
             },
-            F.DESCRIPTION: {"rich_text": [{"text": {"content": description}}]},
+            F.DESCRIPTION: {
+                "rich_text": [{"text": {"content": data.get("description", "")}}]
+            },
             F.COVER: {"files": [{"type": "file_upload", "file_upload": {"id": cover}}]}
             if cover
             else {"files": []},
-            F.PLAY: {"number": play},
-            F.SINGER: {"multi_select": singer or []},
-            F.LYRICIST: {"multi_select": lyricist or []},
-            F.COMPOSER: {"multi_select": composer or []},
-            F.ARRANGER: {"multi_select": arranger or []},
-            F.MIXER: {"multi_select": mixer or []},
-            F.LYRICS: {"rich_text": [{"text": {"content": lyrics}}]},
+            F.PLAY: {"number": data.get("play", 0)},
+            F.SINGER: {"multi_select": data.get("singer") or []},
+            F.LYRICIST: {"multi_select": data.get("lyricist") or []},
+            F.COMPOSER: {"multi_select": data.get("composer") or []},
+            F.ARRANGER: {"multi_select": data.get("arranger") or []},
+            F.MIXER: {"multi_select": data.get("mixer") or []},
+            F.LYRICS: {"rich_text": [{"text": {"content": data.get("lyrics", "")}}]},
             F.PLATFORM: {"multi_select": [{"name": platform}]},
         }
 
     @staticmethod
     def build_partial_properties(
-        update_fields: List[str],
+        update_fields: list[AlbumField],
         time_zone: str = "Asia/Shanghai",
         **kwargs: Any,
     ) -> Dict[str, Any]:
@@ -273,15 +230,11 @@ class NotionClient:
         Returns:
             Notion页面属性字典（仅包含需要更新的字段）
         """
-        # 定义字段名到Notion属性的映射
-        # 每个 lambda 接收 data 和 tz 参数
-        F = AlbumField  # 简化引用
+        F = AlbumField
         field_mapping: Dict[str, Any] = {
-            # 标题类型 (title)
             F.NAME: lambda data, tz: {
                 F.NAME: {"title": [{"text": {"content": data.get("name", "")}}]}
             },
-            # 文件类型 (files)
             F.COVER: lambda data, tz: {
                 F.COVER: {
                     "files": [
@@ -318,14 +271,12 @@ class NotionClient:
             }
             if data.get("cover_square")
             else {},
-            # 数字类型 (number)
             F.PLAY: lambda data, tz: {F.PLAY: {"number": data.get("play", 0)}},
             F.LIKED: lambda data, tz: {F.LIKED: {"number": data.get("liked", 0)}},
             F.PRICE: lambda data, tz: {F.PRICE: {"number": data.get("ori_price", 0)}},
             F.EPISODE_COUNT: lambda data, tz: {
                 F.EPISODE_COUNT: {"number": data.get("episode_count", 0)}
             },
-            # 日期类型 (date)
             F.PUBLISH_DATE: lambda data, tz: {
                 F.PUBLISH_DATE: {
                     "date": {
@@ -336,7 +287,6 @@ class NotionClient:
             }
             if data.get("publish_date")
             else {},
-            # 富文本类型 (rich_text)
             F.DESCRIPTION: lambda data, tz: {
                 F.DESCRIPTION: {
                     "rich_text": [{"text": {"content": data.get("description", "")}}]
@@ -349,7 +299,6 @@ class NotionClient:
                     ]
                 }
             },
-            # 单选类型 (select)
             F.AUTHOR: lambda data, tz: {
                 F.AUTHOR: {"select": {"name": data.get("author_name", "")}}
             }
@@ -370,7 +319,6 @@ class NotionClient:
             }
             if data.get("commercial_drama")
             else {},
-            # 多选类型 (multi_select)
             F.UPDATE_FREQ: lambda data, tz: {
                 F.UPDATE_FREQ: {"multi_select": data.get("update_frequency", [])}
             },
@@ -392,7 +340,6 @@ class NotionClient:
             F.PLATFORM: lambda data, tz: {
                 F.PLATFORM: {"multi_select": [{"name": data.get("platform", "饭角")}]}
             },
-            # URL类型 (url)
             F.ALBUM_LINK: lambda data, tz: {
                 F.ALBUM_LINK: {"url": data.get("album_link", "")}
             }
@@ -412,7 +359,7 @@ class NotionClient:
 
     @staticmethod
     def build_partial_audio_properties(
-        update_fields: List[str],
+        update_fields: list[AudioField],
         time_zone: str = "Asia/Shanghai",
         **kwargs: Any,
     ) -> Dict[str, Any]:
@@ -426,14 +373,11 @@ class NotionClient:
         Returns:
             Notion音频页面属性字典（仅包含需要更新的字段）
         """
-        # 定义字段名到Notion属性的映射
-        F = AudioField  # 简化引用
+        F = AudioField
         field_mapping: Dict[str, Any] = {
-            # 标题类型 (title)
             F.NAME: lambda data: {
                 F.NAME: {"title": [{"text": {"content": data.get("name", "")}}]}
             },
-            # 封面相关
             F.COVER: lambda data: {
                 F.COVER: {
                     "files": [
@@ -446,15 +390,12 @@ class NotionClient:
             }
             if data.get("cover_id")
             else {},
-            # 播放量
             F.PLAY: lambda data: {F.PLAY: {"number": data.get("play", 0)}},
-            # 描述
             F.DESCRIPTION: lambda data: {
                 F.DESCRIPTION: {
                     "rich_text": [{"text": {"content": data.get("description", "")}}]
                 }
             },
-            # 发布日期
             F.PUBLISH_DATE: lambda data: {
                 F.PUBLISH_DATE: {
                     "date": {
@@ -463,7 +404,6 @@ class NotionClient:
                     }
                 }
             },
-            # 音乐制作信息（multi_select）
             F.SINGER: lambda data: {F.SINGER: {"multi_select": data.get("singer", [])}},
             F.LYRICIST: lambda data: {
                 F.LYRICIST: {"multi_select": data.get("lyricist", [])}
@@ -475,7 +415,6 @@ class NotionClient:
                 F.ARRANGER: {"multi_select": data.get("arranger", [])}
             },
             F.MIXER: lambda data: {F.MIXER: {"multi_select": data.get("mixer", [])}},
-            # 歌词（rich_text）
             F.LYRICS: lambda data: {
                 F.LYRICS: {"rich_text": [{"text": {"content": data.get("lyrics", "")}}]}
             },

--- a/app/constants/notion_fields.py
+++ b/app/constants/notion_fields.py
@@ -55,6 +55,10 @@ class AlbumField(StrEnum):
     # URL类型 (url)
     ALBUM_LINK = "Album Link"
 
+    # Notion 页面输入字段（webhook 读取用）
+    FANJIAO_ALBUM_ID = "FanjiaoAlbumID"
+    UPDATE_SELECTION = "Update_selection"
+
 
 class AudioField(StrEnum):
     """Audio 数据库字段名常量"""
@@ -82,3 +86,7 @@ class AudioField(StrEnum):
     COMPOSER = "作曲"
     ARRANGER = "编曲"
     MIXER = "混音"
+
+    # Notion 页面输入字段（webhook 读取用）
+    AUDIO_URL = "Audio_URL"
+    UPDATE_AUDIO_SELECTION = "UpdateAudioSelection"

--- a/app/core/processor.py
+++ b/app/core/processor.py
@@ -9,6 +9,7 @@
 import asyncio
 from typing import List, Dict, Optional
 
+from app.constants.notion_fields import AlbumField, AudioField
 from app.services.fanjiao_service import FanjiaoService
 from app.services.fanjiao_audio_service import FanjiaoAudioService
 from app.services.notion_service import NotionService
@@ -77,7 +78,7 @@ class AlbumProcessor:
         return success
 
     async def update_process_id(
-        self, album_id: str, page_id: str, update_fields: List[str]
+        self, album_id: str, page_id: str, update_fields: list[AlbumField]
     ) -> bool:
         """
         更新已有页面的专辑数据（异步）
@@ -194,7 +195,7 @@ class AudioProcessor:
         album_id: str,
         audio_id: str,
         page_id: str,
-        update_fields: List[str],
+        update_fields: list[AudioField],
     ) -> bool:
         """
         更新已有页面的音频数据（异步）

--- a/app/services/notion_service.py
+++ b/app/services/notion_service.py
@@ -65,7 +65,7 @@ class NotionService:
         self,
         album_data: Dict[str, Any],
         page_id: str,
-        update_fields: list[str],
+        update_fields: list[AlbumField],
     ) -> bool:
         """
         部分更新专辑数据到Notion（异步）
@@ -140,7 +140,7 @@ class NotionService:
         self,
         audio_data: Dict[str, Any],
         page_id: str,
-        update_fields: list[str],
+        update_fields: list[AudioField],
     ) -> bool:
         """
         部分更新音频数据到Notion（异步）
@@ -186,7 +186,7 @@ class NotionService:
     async def _prepare_partial_audio_data(
         self,
         audio_data: Dict[str, Any],
-        update_fields: list[str],
+        update_fields: list[AudioField],
     ) -> Dict[str, Any]:
         """
         根据需要更新的字段准备音频数据（异步）
@@ -361,7 +361,7 @@ class NotionService:
     async def _prepare_partial_data(
         self,
         album_data: Dict[str, Any],
-        update_fields: list[str],
+        update_fields: list[AlbumField],
     ) -> Dict[str, Any]:
         """
         根据需要更新的字段准备数据（异步）


### PR DESCRIPTION
- Add 4 webhook input field constants (FanjiaoAlbumID, Update_selection, Audio_URL, UpdateAudioSelection) to AlbumField/AudioField enums
- Replace hardcoded strings in routes.py with enum references
- Simplify build_properties and build_audio_properties signatures from 20+/13+ explicit params to **kwargs, matching the partial builder pattern
- Remove redundant section comments in build_partial_* field_mapping dicts(already documented in the enum definitions)
- Narrow update_fields type from list[str] to list[AlbumField]/list[AudioField] across routes, processor, service, and client layers